### PR TITLE
Support rspec-puppet v1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 env:
 - PUPPET_VERSION=2.7.23
-- PUPPET_VERSION=3.2.4
+- PUPPET_VERSION=3.3.2
 notifications:
 email: false
 rvm:

--- a/Rakefile
+++ b/Rakefile
@@ -2,11 +2,17 @@ require 'rubygems'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 PuppetLint.configuration.send('disable_80chars')
-PuppetLint.configuration.ignore_paths = ["spec/**/*.pp"]
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
 desc "Run puppet in noop mode and check for syntax errors."
 task :validate do
-   Dir['manifests/**/*.pp'].each do |path|
-     sh "puppet parser validate --noop #{path}"
-   end
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,7 +6,7 @@ describe 'common' do
     context 'default options with supported OS' do
       let(:facts) { {:osfamily => 'RedHat' } }
       it {
-        should include_class('common')
+        should contain_class('common')
       }
     end
 
@@ -14,7 +14,7 @@ describe 'common' do
       let(:facts) { {:osfamily => 'Gentoo' } }
       it do
         expect {
-          should include_class('common')
+          should contain_class('common')
         }.to raise_error(Puppet::Error,/Supported OS families are Debian, RedHat, Solaris, and Suse. Detected osfamily is Gentoo./)
       end
     end
@@ -24,7 +24,7 @@ describe 'common' do
         let(:facts) { {:osfamily => 'RedHat' } }
         let(:params) { {:manage_root_password => true } }
 
-        it { should include_class('common') }
+        it { should contain_class('common') }
 
         it {
           should contain_user('root').with({
@@ -37,7 +37,7 @@ describe 'common' do
         let(:facts) { {:osfamily => 'RedHat' } }
         let(:params) { {:manage_root_password => true, :root_password => 'foo' } }
 
-        it { should include_class('common') }
+        it { should contain_class('common') }
 
         it {
           should contain_user('root').with({
@@ -52,7 +52,7 @@ describe 'common' do
         let(:facts) { {:osfamily => 'RedHat' } }
         let(:params) { {:create_opt_lsb_provider_name_dir=> true, :lsb_provider_name => 'UNSET' } }
 
-        it { should include_class('common') }
+        it { should contain_class('common') }
 
         it {
           should_not contain_file('/opt/UNSET')
@@ -63,7 +63,7 @@ describe 'common' do
         let(:facts) { {:osfamily => 'RedHat' } }
         let(:params) { {:create_opt_lsb_provider_name_dir=> true, :lsb_provider_name => 'foo' } }
 
-        it { should include_class('common') }
+        it { should contain_class('common') }
 
         it {
           should contain_file('/opt/foo').with({


### PR DESCRIPTION
include_class has been replaced with contain_class.
http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/
