### PR TITLE
Use purge_ssh_keys only on Puppet >= 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,9 @@ String - Anything that the ssh_authorized_key resource can take for the type att
 
 purge_ssh_keys
 -----------------
-Boolean - Purge any keys that aren’t managed as ssh_authorized_key resources.
+Boolean - Purge any keys that aren’t managed as ssh_authorized_key resources. As this parameter was introduced with Puppet 3.6,
+it will only work with Puppet >= 3.6. On earlier version this parameter will be silently ignored.
+
 
 - *Default*: false
 

--- a/README.md
+++ b/README.md
@@ -353,6 +353,12 @@ String - Anything that the ssh_authorized_key resource can take for the type att
 
 - *Default*: 'ssh-dss'
 
+purge_ssh_keys
+-----------------
+Boolean - Purge any keys that aren’t managed as ssh_authorized_key resources.
+
+- *Default*: false
+
 ===
 
 # Functions #

--- a/manifests/mkuser.pp
+++ b/manifests/mkuser.pp
@@ -52,6 +52,7 @@ define common::mkuser (
   $ssh_auth_key      = undef,
   $create_group      = true,
   $ssh_auth_key_type = undef,
+  $purge_ssh_key     = undef,
 ) {
 
   if $shell {
@@ -102,17 +103,25 @@ define common::mkuser (
     $mymode = '0700'
   }
 
+  if $purge_ssh_key != undef {
+    $mypurgekey = str2bool($purge_ssh_key)
+    validate_bool($mypurgekey)
+  } else {
+    $mypurgekey = false
+  }
+
   # create user
   user { $name:
-    ensure     => $ensure,
-    uid        => $uid,
-    gid        => $mygid,
-    shell      => $myshell,
-    groups     => $mygroups,
-    password   => $mypassword,
-    managehome => $managehome,
-    home       => $myhome,
-    comment    => $comment,
+    ensure         => $ensure,
+    uid            => $uid,
+    gid            => $mygid,
+    shell          => $myshell,
+    groups         => $mygroups,
+    password       => $mypassword,
+    managehome     => $managehome,
+    home           => $myhome,
+    comment        => $comment,
+    purge_ssh_keys => $mypurgekey,
   } # user
 
   if $create_group {

--- a/manifests/mkuser.pp
+++ b/manifests/mkuser.pp
@@ -110,18 +110,23 @@ define common::mkuser (
     $mypurgekey = false
   }
 
+  if versioncmp($::puppetversion, '3.6') > 0 {
+    User {
+      purge_ssh_keys => $mypurgekey,
+    }
+  }
+
   # create user
   user { $name:
-    ensure         => $ensure,
-    uid            => $uid,
-    gid            => $mygid,
-    shell          => $myshell,
-    groups         => $mygroups,
-    password       => $mypassword,
-    managehome     => $managehome,
-    home           => $myhome,
-    comment        => $comment,
-    purge_ssh_keys => $mypurgekey,
+    ensure     => $ensure,
+    uid        => $uid,
+    gid        => $mygid,
+    shell      => $myshell,
+    groups     => $mygroups,
+    password   => $mypassword,
+    managehome => $managehome,
+    home       => $myhome,
+    comment    => $comment,
   } # user
 
   if $create_group {

--- a/manifests/mkuser.pp
+++ b/manifests/mkuser.pp
@@ -52,7 +52,7 @@ define common::mkuser (
   $ssh_auth_key      = undef,
   $create_group      = true,
   $ssh_auth_key_type = undef,
-  $purge_ssh_key     = undef,
+  $purge_ssh_keys    = undef,
 ) {
 
   if $shell {
@@ -103,8 +103,8 @@ define common::mkuser (
     $mymode = '0700'
   }
 
-  if $purge_ssh_key != undef {
-    $mypurgekey = str2bool($purge_ssh_key)
+  if $purge_ssh_keys != undef {
+    $mypurgekey = str2bool($purge_ssh_keys)
     validate_bool($mypurgekey)
   } else {
     $mypurgekey = false


### PR DESCRIPTION
Based on https://github.com/ghoneycutt/puppet-module-common/pull/44

This patch makes sure that purge_ssh_keys is only used on Puppet clients >= 3.6 for compatibility reasons.