### PR TITLE
Allow disabling purge_ssh_keys usage on Puppetmaster older than 3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ Boolean to include ghoneycutt/suse
 
 - *Default*: false
 
+users_old_puppetmaster
+----------------------
+Boolean to trigger if purge_ssh_keys attribute should be used for user resources created by $users.
+purge_ssh_keys was introduced with Puppet 3.6.0. If your Puppetmaster is older than 3.6.0 it doesn't support that attribute.
+This module is only able to trigger usage of this attribute based on the Puppet client version.
+
+This is purely made to save the lost souls which do use newer Puppet clients than Puppetmasters.
+https://docs.puppetlabs.com/guides/install_puppet/upgrading.html#always-upgrade-the-puppet-master-first
+
+- *Default*: false
+
 ===
 
 # common::mkdir_p define #
@@ -342,7 +353,7 @@ String - mode of home directory
 - *Default*: 0700
 
 ssh_auth_key
------------------
+------------
 String - The ssh key for the user
 
 - *Default*: undef
@@ -354,10 +365,20 @@ String - Anything that the ssh_authorized_key resource can take for the type att
 - *Default*: 'ssh-dss'
 
 purge_ssh_keys
------------------
+--------------
 Boolean - Purge any keys that aren’t managed as ssh_authorized_key resources. As this parameter was introduced with Puppet 3.6,
-it will only work with Puppet >= 3.6. On earlier version this parameter will be silently ignored.
+it will only work with Puppet clients & servers >= 3.6. On earlier version this parameter will be silently ignored.
 
+- *Default*: false
+
+old_puppetmaster
+----------------
+Boolean to trigger if purge_ssh_keys attribute should be used for user resources created by $users.
+purge_ssh_keys was introduced with Puppet 3.6.0. If your Puppetmaster is older than 3.6.0 it doesn't support that attribute.
+This module is only able to trigger usage of this attribute based on the Puppet client version.
+
+This is purely made to save the lost souls which do use newer Puppet clients than Puppetmasters.
+https://docs.puppetlabs.com/guides/install_puppet/upgrading.html#always-upgrade-the-puppet-master-first
 
 - *Default*: false
 

--- a/commit.msg
+++ b/commit.msg
@@ -1,0 +1,1 @@
+Allow to disable purge_ssh_keys usage on Puppetmaster older than 3.6.0

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class common (
   $enable_redhat                    = false,
   $enable_solaris                   = false,
   $enable_suse                      = false,
+  $users_old_puppetmaster           = false,
 ) {
 
   # validate type and convert string to boolean if necessary
@@ -292,10 +293,24 @@ class common (
     }
   }
 
+  # validate type and convert string to boolean if necessary
+  if is_string($users_old_puppetmaster) {
+    $users_old_puppetmaster_real = str2bool($users_old_puppetmaster)
+  } else {
+    $users_old_puppetmaster_real = $users_old_puppetmaster
+  }
+
   if $users != undef {
+    if $users_old_puppetmaster_real == true {
+      $default_options = {
+        'old_puppetmaster' => true,
+      }
+    } else {
+      $default_options = {}
+    }
 
     # Create virtual user resources
-    create_resources('@common::mkuser',$common::users)
+    create_resources('@common::mkuser',$common::users, $default_options)
 
     # Collect all virtual users
     Common::Mkuser <||>

--- a/manifests/mkuser.pp
+++ b/manifests/mkuser.pp
@@ -53,6 +53,7 @@ define common::mkuser (
   $create_group      = true,
   $ssh_auth_key_type = undef,
   $purge_ssh_keys    = undef,
+  $old_puppetmaster  = false,
 ) {
 
   if $shell {
@@ -110,9 +111,18 @@ define common::mkuser (
     $mypurgekey = false
   }
 
-  if versioncmp($::puppetversion, '3.6') > 0 {
-    User {
-      purge_ssh_keys => $mypurgekey,
+  # validate type and convert string to boolean if necessary
+  if is_string($old_puppetmaster) {
+    $old_puppetmaster_real = str2bool($old_puppetmaster)
+  } else {
+    $old_puppetmaster_real = $old_puppetmaster
+  }
+
+  if $old_puppetmaster_real == false {
+    if versioncmp($::puppetversion, '3.6') > 0 {
+      User {
+        purge_ssh_keys => $mypurgekey,
+      }
     }
   }
 


### PR DESCRIPTION
This fixes the issue described in https://github.com/ghoneycutt/puppet-module-common/issues/47
