### PR TITLE
Updated Dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <2.0.0"},
+    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <3.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 7.0.0"}
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -12,8 +12,8 @@
     {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <4.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 8.0.0"}
+    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <2.1.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.4.0"}
   ],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -12,8 +12,8 @@
     {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <2.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
+    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <4.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 8.0.0"}
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Modified module dependencies to correct warnings being thrown when `puppet module list` command is run on puppet master. Changed dependency maximum versions in the `metadata.json` to correct the warnings and invalid module dependencies. 
Please note that I used version numbers exceeding the current versions of the dependencies to account for future dependency releases.

These are the warnings that I get when I run the `puppet module list` command. 
```
root@servernode:~# puppet module list
Warning: Module 'puppetlabs-sshkeys_core' (v2.0.0) fails to meet some dependencies:
  'ghoneycutt-common' (v1.9.0) requires 'puppetlabs-sshkeys_core' (>= 1.0.1 <2.0.0)
Warning: Module 'puppetlabs-stdlib' (v6.3.0) fails to meet some dependencies:
  'ghoneycutt-common' (v1.9.0) requires 'puppetlabs-stdlib' (>= 4.6.0 < 6.0.0)

/etc/puppetlabs/code/environments/production/modules
├── puppetlabs-sshkeys_core (v2.0.0)  invalid
├── puppetlabs-stdlib (v6.3.0)  invalid
```
This pull request fixes these warnings. 