### PR TITLE
Updated Module Dependency Version Range for sshkeys_core 

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <2.0.0"},
+    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <3.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 7.0.0"}
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -12,8 +12,8 @@
     {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <4.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 8.0.0"}
+    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <2.1.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.4.0"}
   ],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -12,8 +12,8 @@
     {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <2.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
+    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <4.0.0"},
+    {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 8.0.0"}
   ],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,7 @@
     {"name":"puppet","version_requirement":">= 3.0.0 < 7.0.0"}
   ],
   "dependencies": [
-    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 <3.0.0"},
+    {"name":"puppetlabs/sshkeys_core","version_requirement":">= 1.0.1 < 3.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 7.0.0"}
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Updated the module dependency version range for sshkeys_core in the metadata.json to include the latest version. This fixes the following warning when the `puppet module list` command is run. 
```
Warning: Module 'puppetlabs-sshkeys_core' (v2.1.0) fails to meet some dependencies:
  'ghoneycutt-common' (v1.10.0) requires 'puppetlabs-sshkeys_core' (>= 1.0.1 <2.0.0)
```